### PR TITLE
pi/common: switch kernel to 5.12.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,11 +131,11 @@ Here are the boards/systems currently supported:
 | [OrangePi Zero]      | [orangepi/zero]    | ✔ U-Boot 2018.07     | ✔ 5.12.13       |                        |
 | [PcDuino 3]          | [pcduino/3]        | ✔ U-Boot 2019.07     | ✔ 5.12.13       |                        |
 | [PcEngines APU2]     | [pcengines/apu2]   | ✔ CoreBoot           | ✔ 5.12.13       |                        |
-| [Pi 0]               | [pi/0]             | N/A                  | ✔ rpi-5.10.44   | ✔ Tested               |
-| [Pi 1]               | [pi/1]             | N/A                  | ✔ rpi-5.10.44   |                        |
-| [Pi 3] + 1, 2        | [pi/3]             | N/A                  | ✔ rpi-5.10.44   | ✔ Tested               |
-| [Pi 4]               | [pi/4]             | N/A                  | ✔ rpi-5.10.44   | ✔ Tested               |
-| [Pi 4] (32bit mode)  | [pi/4x32]          | N/A                  | ✔ rpi-5.10.44   | ✔ Tested               |
+| [Pi 0]               | [pi/0]             | N/A                  | ✔ rpi-5.12.10   | ✔ Tested               |
+| [Pi 1]               | [pi/1]             | N/A                  | ✔ rpi-5.12.10   |                        |
+| [Pi 3] + 1, 2        | [pi/3]             | N/A                  | ✔ rpi-5.12.10   | ✔ Tested               |
+| [Pi 4]               | [pi/4]             | N/A                  | ✔ rpi-5.12.10   | ✔ Tested               |
+| [Pi 4] (32bit mode)  | [pi/4x32]          | N/A                  | ✔ rpi-5.12.10   | ✔ Tested               |
 | [Pine64] H64         | [pine64/h64]       | ✔ U-Boot             | ✔ pine64-5.8.0  | ✔ Tested               |
 | [PineBook Pro]       | [pine64/book]      | ✔ U-Boot (bin)       | ✔ ayufan-5.12.0 | ✔ Tested               |
 | [PinePhone]          | [pine64/phone]     | ✔ U-Boot (bin)       | ✔ megi-5.13-rc6 | ✔ Tested               |

--- a/configs/pi/common/buildroot/kernel
+++ b/configs/pi/common/buildroot/kernel
@@ -1,10 +1,10 @@
 BR2_LINUX_KERNEL_CUSTOM_TARBALL=y
 
 # rpi-5.10.y branch
-BR2_LINUX_KERNEL_CUSTOM_TARBALL_LOCATION="https://github.com/raspberrypi/linux/archive/2b13c54592135b6fab269517ed687fa9f80bf8e5/linux-rpi-5.10.44-r1.tar.gz"
-BR2_PACKAGE_HOST_LINUX_HEADERS_CUSTOM_5_10=y
+# BR2_LINUX_KERNEL_CUSTOM_TARBALL_LOCATION="https://github.com/raspberrypi/linux/archive/2b13c54592135b6fab269517ed687fa9f80bf8e5/linux-rpi-5.10.44-r1.tar.gz"
+# BR2_PACKAGE_HOST_LINUX_HEADERS_CUSTOM_5_10=y
 
 # rpi-5.12.y branch
-# BR2_LINUX_KERNEL_CUSTOM_TARBALL_LOCATION="https://github.com/raspberrypi/linux/archive/68c813a66c870fbbfe89b3525e14b83ef498a9a9/linux-rpi-5.12.6-r2.tar.gz"
+BR2_LINUX_KERNEL_CUSTOM_TARBALL_LOCATION="https://github.com/raspberrypi/linux/archive/490c3135149347db2d4479fb6866fd8e0a862eae/linux-rpi-5.12.10-r1.tar.gz"
 
 BR2_KERNEL_HEADERS_AS_KERNEL=y


### PR DESCRIPTION
Switches to 5.12.y branch.

Note: Pi OS is currently (as of 2021-06-03) still on 5.10.y branch.

(This is marked as a draft as such)