### PR TITLE
next: bump buildroot to 2021.05

### DIFF
--- a/configs-base/pre/buildroot/kernel
+++ b/configs-base/pre/buildroot/kernel
@@ -7,7 +7,7 @@ BR2_LINUX_KERNEL_NEEDS_HOST_OPENSSL=y
 
 # "mainline" kernel applied from configs-base/pre
 # these may be overridden by SKIFF_CONFIG layers
-BR2_PACKAGE_HOST_LINUX_HEADERS_CUSTOM_5_10=y
+BR2_PACKAGE_HOST_LINUX_HEADERS_CUSTOM_5_12=y
 BR2_LINUX_KERNEL_CUSTOM_VERSION=y
 
 # "stable" branch:

--- a/configs/odroid/common/buildroot/kernel
+++ b/configs/odroid/common/buildroot/kernel
@@ -1,11 +1,9 @@
 BR2_LINUX_KERNEL=y
 BR2_LINUX_KERNEL_CUSTOM_TARBALL=y
 
-# tobetter odroid-5.11.y branch (previous version)
-# BR2_LINUX_KERNEL_CUSTOM_TARBALL_LOCATION="https://github.com/tobetter/linux/archive/da0cd69598edc1735beca2765394d7f141b2baa6/linux-odroid-tb-5.11.14-r1.tar.gz"
-
 # tobetter odroid-5.11.y branch
 BR2_LINUX_KERNEL_CUSTOM_TARBALL_LOCATION="https://github.com/tobetter/linux/archive/a5b0f896fba4385d7b847bc92b4cb6b5d43e5a4d/linux-odroid-tb-5.11.18-r1.tar.gz"
+BR2_PACKAGE_HOST_LINUX_HEADERS_CUSTOM_5_11=y
 
 BR2_LINUX_KERNEL_USE_ARCH_DEFAULT_CONFIG=y
 BR2_KERNEL_HEADERS_AS_KERNEL=y


### PR DESCRIPTION
Bumps the "master" series to 2021.05 while "stable" will remain on 2021.02.x LTS.