### PR TITLE
[NEXT] pi/common: bump kernel to 5.13.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,11 +131,11 @@ Here are the boards/systems currently supported:
 | [OrangePi Zero]      | [orangepi/zero]    | ✔ U-Boot 2018.07     | ✔ 5.13.1        |                        |
 | [PcDuino 3]          | [pcduino/3]        | ✔ U-Boot 2019.07     | ✔ 5.13.1        |                        |
 | [PcEngines APU2]     | [pcengines/apu2]   | ✔ CoreBoot           | ✔ 5.13.1        |                        |
-| [Pi 0]               | [pi/0]             | N/A                  | ✔ rpi-5.10.48   | ✔ Tested               |
-| [Pi 1]               | [pi/1]             | N/A                  | ✔ rpi-5.10.48   |                        |
-| [Pi 3] + 1, 2        | [pi/3]             | N/A                  | ✔ rpi-5.10.48   | ✔ Tested               |
-| [Pi 4]               | [pi/4]             | N/A                  | ✔ rpi-5.10.48   | ✔ Tested               |
-| [Pi 4] (32bit mode)  | [pi/4x32]          | N/A                  | ✔ rpi-5.10.48   | ✔ Tested               |
+| [Pi 0]               | [pi/0]             | N/A                  | ✔ rpi-5.13.1    | ✔ Tested               |
+| [Pi 1]               | [pi/1]             | N/A                  | ✔ rpi-5.13.1    |                        |
+| [Pi 3] + 1, 2        | [pi/3]             | N/A                  | ✔ rpi-5.13.1    | ✔ Tested               |
+| [Pi 4]               | [pi/4]             | N/A                  | ✔ rpi-5.13.1    | ✔ Tested               |
+| [Pi 4] (32bit mode)  | [pi/4x32]          | N/A                  | ✔ rpi-5.13.1    | ✔ Tested               |
 | [Pine64] H64         | [pine64/h64]       | ✔ U-Boot             | ✔ pine64-5.8.0  | ✔ Tested               |
 | [PineBook Pro]       | [pine64/book]      | ✔ U-Boot (bin)       | ✔ ayufan-5.12.0 | ✔ Tested               |
 | [PinePhone]          | [pine64/phone]     | ✔ U-Boot (bin)       | ✔ megi-5.13     | ✔ Tested               |

--- a/configs/pi/common/buildroot/kernel
+++ b/configs/pi/common/buildroot/kernel
@@ -1,10 +1,10 @@
 BR2_LINUX_KERNEL_CUSTOM_TARBALL=y
 
 # rpi-5.10.y branch
-BR2_LINUX_KERNEL_CUSTOM_TARBALL_LOCATION="https://github.com/raspberrypi/linux/archive/4d94d5c99bf36f3a11529277d3c7eef455ca352c/linux-rpi-5.10.48-r1.tar.gz"
-BR2_PACKAGE_HOST_LINUX_HEADERS_CUSTOM_5_10=y
+# BR2_LINUX_KERNEL_CUSTOM_TARBALL_LOCATION="https://github.com/raspberrypi/linux/archive/4d94d5c99bf36f3a11529277d3c7eef455ca352c/linux-rpi-5.10.48-r1.tar.gz"
+# BR2_PACKAGE_HOST_LINUX_HEADERS_CUSTOM_5_10=y
 
 # rpi-5.13.y branch
-# BR2_LINUX_KERNEL_CUSTOM_TARBALL_LOCATION="https://github.com/raspberrypi/linux/archive/ed0e8a7b32a3bdc9118d7191dea305ebaaf1722c/linux-rpi-5.13.1-r1.tar.gz"
+BR2_LINUX_KERNEL_CUSTOM_TARBALL_LOCATION="https://github.com/raspberrypi/linux/archive/ed0e8a7b32a3bdc9118d7191dea305ebaaf1722c/linux-rpi-5.13.1-r1.tar.gz"
 
 BR2_KERNEL_HEADERS_AS_KERNEL=y


### PR DESCRIPTION
Bumps the Pi kernel to the 5.13.x branch.

Currently the Pi foundation is using 5.10.x as the main stable branch, so "master" will stay on that for now.