### PR TITLE
Fixing wrong determination of partitions.

### DIFF
--- a/configs/pine64/common/scripts/format_sd.sh
+++ b/configs/pine64/common/scripts/format_sd.sh
@@ -90,6 +90,7 @@ sleep 2
 partprobe $PINE64_SD || true
 
 PINE64_SD_SFX=$PINE64_SD
+sleep 2
 if [ -b ${PINE64_SD}p1 ]; then
   PINE64_SD_SFX=${PINE64_SD}p
 fi


### PR DESCRIPTION
Preventing error while evaluating if the partitions have p0, p1, etc. or just 0, 1, etc. at the end. The determination process takes place before the partitions appear in /dev/. Sleeping 2 seconds is fixing this.