### PR TITLE
build/docker: use python3 instead of python

### DIFF
--- a/build/docker/Dockerfile.ubuntu
+++ b/build/docker/Dockerfile.ubuntu
@@ -2,8 +2,9 @@ FROM ubuntu:latest
 RUN apt update && \
     apt install -y build-essential \
     git gcc wget curl musl-dev file \
-    perl python rsync bc patch unzip cpio
+    perl python3 rsync bc patch unzip cpio
 RUN adduser --gecos "Buildroot" --disabled-login --uid 1000 buildroot && \
     mkdir -p /home/buildroot && chown buildroot:buildroot /home/buildroot
 USER buildroot
+ENV LANG C.UTF-8
 WORKDIR /home/buildroot


### PR DESCRIPTION
python is not sufficient, python3 is required