### PR TITLE
Update README with additional Qemu info

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,6 +486,9 @@ export SKIFF_WORKSPACE=qemu
 export SKIFF_CONFIG=virt/qemu,core/gentoo,util/rootlogin
 mkdir -p ./overrides/workspaces/qemu/buildroot
 echo "BR2_riscv=y" > ./overrides/workspaces/qemu/buildroot/arch
+echo "BR2_PACKAGE_HOST_GENEXT2FS=y
+BR2_PACKAGE_HOST_GENIMAGE=y
+BR2_PACKAGE_HOST_E2FSPROGS=y" > ./overrides/workspaces/qemu/buildroot/genimage
 make compile
 ```
 


### PR DESCRIPTION
Added additional buildroot config info for running QEMU for different architectures (example is RISCV).

The doc for running QEMU for different architectures didn't include a config needed to compile genimage that is needed to build the image.