### PR TITLE
odroid/common: bump kernel to tobetter 6.1.y branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,16 +71,16 @@ main SkiffOS repository:
 | [NVIDIA Jetson AGX]   | [jetson/agx]          | ✔ UEFI           | ✔ [nv-5.10.104] | ✔ Tested         |
 | [NVIDIA Jetson Nano]  | [jetson/nano]         | ✔ U-Boot         | ✔ [nv-4.9.309]  | ⚠ Obsolete       |
 | [NVIDIA Jetson TX2]   | [jetson/tx2]          | ✔ U-Boot         | ✔ [nv-4.9.309]  | ⚠ Obsolete       |
-| [Odroid C2]           | [odroid/c2]           | ✔ U-Boot 2022.07 | ✔ tb-6.0.7      | ⚠ Obsolete       |
-| [Odroid C4]           | [odroid/c4]           | ✔ U-Boot 2022.07 | ✔ tb-6.0.7      |                  |
-| [Odroid HC1]          | [odroid/xu]           | ✔ U-Boot 2017.07 | ✔ tb-6.0.7      | ⚠ Obsolete       |
-| [Odroid HC2]          | [odroid/xu]           | ✔ U-Boot 2017.07 | ✔ tb-6.0.7      | ✔ Tested         |
-| [Odroid HC4]          | [odroid/hc4]          | ✔ U-Boot 2022.07 | ✔ tb-6.0.7      |                  |
-| [Odroid M1]           | [odroid/m1]           | ✔ U-Boot 2017.09 | ✔ tb-6.0.7      |                  |
-| [Odroid N2]+          | [odroid/n2]           | ✔ U-Boot 2022.07 | ✔ tb-6.0.7      | ✔ Tested         |
-| [Odroid U]            | [odroid/u]            | ✔ U-Boot 2022.07 | ✔ tb-6.0.7      | ⚠ Obsolete       |
-| [Odroid XU3]          | [odroid/xu]           | ✔ U-Boot 2017.07 | ✔ tb-6.0.7      | ⚠ Obsolete       |
-| [Odroid XU4]          | [odroid/xu]           | ✔ U-Boot 2017.07 | ✔ tb-6.0.7      | ✔ Tested         |
+| [Odroid C2]           | [odroid/c2]           | ✔ U-Boot 2022.07 | ✔ tb-6.1.2      | ⚠ Obsolete       |
+| [Odroid C4]           | [odroid/c4]           | ✔ U-Boot 2022.07 | ✔ tb-6.1.2      |                  |
+| [Odroid HC1]          | [odroid/xu]           | ✔ U-Boot 2017.07 | ✔ tb-6.1.2      | ⚠ Obsolete       |
+| [Odroid HC2]          | [odroid/xu]           | ✔ U-Boot 2017.07 | ✔ tb-6.1.2      | ✔ Tested         |
+| [Odroid HC4]          | [odroid/hc4]          | ✔ U-Boot 2022.07 | ✔ tb-6.1.2      |                  |
+| [Odroid M1]           | [odroid/m1]           | ✔ U-Boot 2017.09 | ✔ tb-6.1.2      |                  |
+| [Odroid N2]+          | [odroid/n2]           | ✔ U-Boot 2022.07 | ✔ tb-6.1.2      | ✔ Tested         |
+| [Odroid U]            | [odroid/u]            | ✔ U-Boot 2022.07 | ✔ tb-6.1.2      | ⚠ Obsolete       |
+| [Odroid XU3]          | [odroid/xu]           | ✔ U-Boot 2017.07 | ✔ tb-6.1.2      | ⚠ Obsolete       |
+| [Odroid XU4]          | [odroid/xu]           | ✔ U-Boot 2017.07 | ✔ tb-6.1.2      | ✔ Tested         |
 | [OrangePi Lite]       | [orangepi/lite]       | ✔ U-Boot 2018.05 | ✔ 6.1.2         |                  |
 | [OrangePi Zero]       | [orangepi/zero]       | ✔ U-Boot 2018.07 | ✔ 6.1.2         |                  |
 | [PcDuino 3]           | [pcduino/3]           | ✔ U-Boot 2019.07 | ✔ 6.1.2         |                  |

--- a/configs/odroid/common/buildroot/kernel
+++ b/configs/odroid/common/buildroot/kernel
@@ -1,14 +1,15 @@
 BR2_LINUX_KERNEL=y
 BR2_LINUX_KERNEL_CUSTOM_TARBALL=y
 
-# skiffos odroid-5.18.y branch: tobetter fork w/ xu4 support
-# skiff-odroid-5.18.y-9
-# BR2_LINUX_KERNEL_CUSTOM_TARBALL_LOCATION="$(call github,skiffos,linux,4 ef146a921e99963f0ead603db857cb994fb11dd)/linux-skiff-odroid-5.18.12-r4.tar.gz"
-# BR2_PACKAGE_HOST_LINUX_HEADERS_CUSTOM_5_18=y
+# skiff-odroid-6.0.y branch: tobetter fork w/ xu4 support
+# skiff-odroid-6.0.y-1
+# BR2_LINUX_KERNEL_CUSTOM_TARBALL_LOCATION="$(call github,skiffos,linux,72ddaa6e2a03cba47c6a57bb44953112752d38b5)/linux-skiff-odroid-6.0.7-r1.tar.gz"
+# BR2_PACKAGE_HOST_LINUX_HEADERS_CUSTOM_6_0=y
 
-# skiffos odroid-6.0.y branch: tobetter fork w/ xu4 support
-BR2_LINUX_KERNEL_CUSTOM_TARBALL_LOCATION="$(call github,skiffos,linux,72ddaa6e2a03cba47c6a57bb44953112752d38b5)/linux-skiff-odroid-6.0.7-r1.tar.gz"
-BR2_PACKAGE_HOST_LINUX_HEADERS_CUSTOM_6_0=y
+# skiff-odroid-6.1.y branch: tobetter fork w/ xu4 support
+# skiff-odroid-6.1.y-2
+BR2_LINUX_KERNEL_CUSTOM_TARBALL_LOCATION="$(call github,skiffos,linux,dbd726737011972810d4e4d2f211cdb4b5db8c3d)/linux-skiff-odroid-6.1.2-r1.tar.gz"
+BR2_PACKAGE_HOST_LINUX_HEADERS_CUSTOM_6_1=y
 
 BR2_LINUX_KERNEL_USE_ARCH_DEFAULT_CONFIG=y
 BR2_KERNEL_HEADERS_AS_KERNEL=y


### PR DESCRIPTION
Needs testing:

 - [x] odroid xu4
 - [x] odroid hc2
 - [x] odroid m1
 - [x] odroid n2
 - [x] odroid c4 / hc4
