### PR TITLE
pi/4x64: fix drm memory error

### DIFF
--- a/configs/pi/4x64/resources/rpi/cmdline.txt
+++ b/configs/pi/4x64/resources/rpi/cmdline.txt
@@ -1,1 +1,1 @@
-console=tty1 console=ttyAMA0,115200 root=/dev/ram0 ro net.ifnames=0 dwc_otg.lpm_enable=0 cgroup_enable=cpuset cgroup_enable=memory
+console=tty1 console=ttyAMA0,115200 root=/dev/ram0 ro net.ifnames=0 dwc_otg.lpm_enable=0 cgroup_enable=cpuset cgroup_enable=memory usbhid.mousepoll=0 consoleblank=0 cma=384M

--- a/configs/pi/4x64/resources/rpi/config.txt
+++ b/configs/pi/4x64/resources/rpi/config.txt
@@ -19,18 +19,6 @@ dtoverlay=miniuart-bt
 # enable autoprobing of Bluetooth driver without need of hciattach/btattach
 dtoverlay=krnbt=on
 
-# GPU memory
-gpu_mem_256=128
-gpu_mem_512=256
-gpu_mem_1024=512
-
-# Disable overscan assuming the display supports displaying the full resolution
-# If the text shown on the screen disappears off the edge, comment this out
-disable_overscan=1
-
-# Force hdmi hotplug
-hdmi_force_hotplug=1
-
 # Avoid pi safe mode
 avoid_safe_mode=1
 
@@ -59,6 +47,26 @@ dtparam=audio=on
 
 # Forces CPU to run in turbo for initial seconds
 # initial_turbo=45
+
+# GPU memory split
+# gpu_mem_256=128
+# gpu_mem_512=256
+# gpu_mem_1024=512
+
+# Disable overscan assuming the display supports displaying the full resolution
+# If the text shown on the screen disappears off the edge, comment this out
+disable_overscan=1
+
+# Force hdmi hotplug
+hdmi_force_hotplug=1
+
+# Uncomment to force HD and prevent 4k memory drain
+# hdmi_group=1
+# hdmi_mode=16
+# [hdmi:0]
+# hdmi_max_pixel_freq=200000000
+# [hdmi:1]
+# hdmi_max_pixel_freq=200000000
 
 # Settings specific to Raspberry Pi 4.
 [pi4]


### PR DESCRIPTION
Fix the following error starting Xorg:

  $ Xorg
  DRM_IOCTL_MODE_CREATE_DUMB failed: Cannot allocate memory
  Failed to create scanout resource

Add cma to cmdline.txt and comment the GPU split in config.txt.

https://retropie.org.uk/forum/topic/24436/drm_ioctl_mode_create_dumb-failed-cannot-allocate-memory/8