### PR TITLE
virt/incus: Fix buildimage and run scripts

### DIFF
--- a/configs/virt/incus/README.md
+++ b/configs/virt/incus/README.md
@@ -42,5 +42,5 @@ delete it, and it will be recreated:
 ```sh
 # You can find the right storage pool with:
 # incus storage list -c n -f csv | head -n 1
-$ incus volume delete "${STORAGE_POOL}" skiff-persist
+$ incus storage volume delete "${STORAGE_POOL}" skiff-persist
 ```

--- a/configs/virt/incus/scripts/buildimage.sh
+++ b/configs/virt/incus/scripts/buildimage.sh
@@ -1,22 +1,14 @@
 #!/bin/bash
-set -ex
+set -eu
 
 IMAGE_NAME=skiffos/testing
 CONTAINER=skiff
 OUTPUT_PATH="$BUILDROOT_DIR/output"
 IMAGES_PATH="$BUILDROOT_DIR/images"
-WORKING_PATH="${BUILDROOT_DIR}/nspawn-run"
-PERSIST_PATH="${WORKING_PATH}/nspawn-persist"
-INCUS_IMAGE_PATH="${IMAGE_PATH}/incus.tar.gz"
+INCUS_IMAGE_PATH="${IMAGES_PATH}/incus.tar.gz"
 roottar="${IMAGES_PATH}/rootfs.tar"
 
-if ! command -v incus >/dev/null 2>&1; then
-	echo "Failed to find the incus command. Is incus installed on your host system?"
-	exit 1
-fi
-
-mkdir -p "${PERSIST_PATH}"
-TMPDIR="${WORKING_PATH}/incus-tmp"
+TMPDIR="${BUILDROOT_DIR}/incus-tmp"
 trap 'rm -rf "$TMPDIR";' EXIT
 rm -rf "$TMPDIR"
 mkdir -p "${TMPDIR}/rootfs"

--- a/configs/virt/incus/scripts/run.sh
+++ b/configs/virt/incus/scripts/run.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
-set -e
+set -eu
 
 IMAGE_NAME=skiffos/testing
 CONTAINER=skiff
 IMAGES_PATH="$BUILDROOT_DIR/images"
-INCUS_IMAGE_PATH="${IMAGE_PATH}/incus.tar.gz"
+INCUS_IMAGE_PATH="${IMAGES_PATH}/incus.tar.gz"
 
 if ! command -v incus >/dev/null 2>&1; then
 	echo "Failed to find the incus command. Is incus installed on your host system?"
@@ -27,7 +27,7 @@ if ! incus storage volume show "$storage_pool" skiff-persist >/dev/null 2>&1; th
 	incus storage volume create "$storage_pool" "skiff-persist"
 fi
 
-if incus show "${CONTAINER}"; then
+if incus info "${CONTAINER}" > /dev/null 2>&1; then
 	incus stop "${CONTAINER}" || :
 	incus rm -f "${CONTAINER}" || :
 fi


### PR DESCRIPTION
Unfortunately I missed a few typos in the scripts. Also, the check for the incus command is now unnecessary in the buildimage script, because it only creates the archive and doesn't actually import it yet, so I removed that (that's for example relevant for my use case where I build in a different container than I use to run the incus container).

The new versions of the scripts are now verified working. Sorry for the inconvenience. 