### PR TITLE
Feature/build incus image in container

### DIFF
--- a/configs/virt/incus/README.md
+++ b/configs/virt/incus/README.md
@@ -42,5 +42,5 @@ delete it, and it will be recreated:
 ```sh
 # You can find the right storage pool with:
 # incus storage list -c n -f csv | head -n 1
-$ incus volume delete "${STORAGE_POOL}" skiff-persist
+$ incus storage volume delete "${STORAGE_POOL}" skiff-persist
 ```

--- a/configs/virt/incus/scripts/buildimage.sh
+++ b/configs/virt/incus/scripts/buildimage.sh
@@ -1,22 +1,14 @@
 #!/bin/bash
-set -ex
+set -eu
 
 IMAGE_NAME=skiffos/testing
 CONTAINER=skiff
 OUTPUT_PATH="$BUILDROOT_DIR/output"
 IMAGES_PATH="$BUILDROOT_DIR/images"
-WORKING_PATH="${BUILDROOT_DIR}/nspawn-run"
-PERSIST_PATH="${WORKING_PATH}/nspawn-persist"
-INCUS_IMAGE_PATH="${IMAGE_PATH}/incus.tar.gz"
+INCUS_IMAGE_PATH="${IMAGES_PATH}/incus.tar.gz"
 roottar="${IMAGES_PATH}/rootfs.tar"
 
-if ! command -v incus >/dev/null 2>&1; then
-	echo "Failed to find the incus command. Is incus installed on your host system?"
-	exit 1
-fi
-
-mkdir -p "${PERSIST_PATH}"
-TMPDIR="${WORKING_PATH}/incus-tmp"
+TMPDIR="${BUILDROOT_DIR}/incus-tmp"
 trap 'rm -rf "$TMPDIR";' EXIT
 rm -rf "$TMPDIR"
 mkdir -p "${TMPDIR}/rootfs"

--- a/configs/virt/incus/scripts/buildimage.sh
+++ b/configs/virt/incus/scripts/buildimage.sh
@@ -3,17 +3,34 @@ set -eu
 
 IMAGE_NAME=skiffos/testing
 CONTAINER=skiff
-OUTPUT_PATH="$BUILDROOT_DIR/output"
-IMAGES_PATH="$BUILDROOT_DIR/images"
-INCUS_IMAGE_PATH="${IMAGES_PATH}/incus.tar.gz"
-roottar="${IMAGES_PATH}/rootfs.tar"
+#IMAGES_PATH="$BUILDROOT_DIR/images"
 
-TMPDIR="${BUILDROOT_DIR}/incus-tmp"
-trap 'rm -rf "$TMPDIR";' EXIT
-rm -rf "$TMPDIR"
-mkdir -p "${TMPDIR}/rootfs"
-tar -xf "$roottar" -C "$TMPDIR/rootfs"
-pushd "$TMPDIR"
+if ! command -v incus >/dev/null 2>&1; then
+	echo "Failed to find the incus command. Is incus installed on your host system?"
+	exit 1
+fi
+
+# create utility container
+echo "Creating builder container..."
+trap 'incus rm -f skiff-builder' EXIT
+incus create images:alpine/3.20 skiff-builder
+incus config device add skiff-builder buildsource disk shift=true source="${BUILDROOT_DIR}" path="/mnt/build"
+incus start skiff-builder
+for i in {1..10}
+do
+  echo "Install container dependencies (attempt $i/10)..."
+  if incus exec skiff-builder -- apk add tar bash
+  then
+    break
+  elif [[ "$i" == 10 ]]
+  then
+    echo "Failed to install container dependencies"
+    exit 1
+  fi
+  sleep 3
+done
+echo "done."
+
 creationtime="$(date +%s)"
 default_metadata="architecture: x86_64
 creation_date: $creationtime
@@ -21,8 +38,30 @@ properties:
   description: SkiffOS
   os: Linux x86
   release: unknown"
-echo "${INCUS_METADATA:-"${default_metadata}"}" >"${TMPDIR}/metadata.yaml"
-tar caf "${INCUS_IMAGE_PATH}" rootfs metadata.yaml
-popd
+
+TMPDIR_HOST="${BUILDROOT_DIR}/incus-tmp"
+touch "${BUILDROOT_DIR}/uid_test"
+trap 'rm "${BUILDROOT_DIR}/uid_test"; incus rm -f skiff-builder' EXIT
+
+incus exec skiff-builder -- bash <<EOF
+set -eux
+
+OUTPUT_PATH="/mnt/build/output"
+IMAGES_PATH="/mnt/build/images"
+INCUS_IMAGE_PATH="\${IMAGES_PATH}/incus.tar.gz"
+roottar="\${IMAGES_PATH}/rootfs.tar"
+TMPDIR="/tmp/skiff/incus"
+
+rm -rf "\$TMPDIR"
+trap 'rm -rf \${TMPDIR}' EXIT
+mkdir -p "\${TMPDIR}/rootfs"
+tar --same-owner -xf "\$roottar" -C "\${TMPDIR}/rootfs"
+cd "\$TMPDIR"
+echo "${INCUS_METADATA:-"${default_metadata}"}" > "\${TMPDIR}/metadata.yaml"
+tar caf "\${INCUS_IMAGE_PATH}" rootfs metadata.yaml
+host_user_id="\$(stat -c '%u' "/mnt/build/uid_test")"
+host_group_id="\$(stat -c '%g' "/mnt/build/uid_test")"
+chown "\${host_user_id}:\${host_group_id}" "\${INCUS_IMAGE_PATH}"
+EOF
 
 echo "Incus image generated successfully as ${IMAGE_NAME}"

--- a/configs/virt/incus/scripts/run.sh
+++ b/configs/virt/incus/scripts/run.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
-set -e
+set -eu
 
 IMAGE_NAME=skiffos/testing
 CONTAINER=skiff
 IMAGES_PATH="$BUILDROOT_DIR/images"
-INCUS_IMAGE_PATH="${IMAGE_PATH}/incus.tar.gz"
+INCUS_IMAGE_PATH="${IMAGES_PATH}/incus.tar.gz"
 
 if ! command -v incus >/dev/null 2>&1; then
 	echo "Failed to find the incus command. Is incus installed on your host system?"
@@ -27,7 +27,7 @@ if ! incus storage volume show "$storage_pool" skiff-persist >/dev/null 2>&1; th
 	incus storage volume create "$storage_pool" "skiff-persist"
 fi
 
-if incus show "${CONTAINER}"; then
+if incus info "${CONTAINER}" > /dev/null 2>&1; then
 	incus stop "${CONTAINER}" || :
 	incus rm -f "${CONTAINER}" || :
 fi


### PR DESCRIPTION
So far, the incus container image is built on the host with the executing (potentially unprivileged) users' permissions. During the build, the following steps are performed (among others)

1. Extract the rootfs.tar to a temporary directory
2. Generate a metadata.yaml for the incus image
3. Package the extracted rootfs directory and the metadata.yaml into a new tarball that can be imported into incus as container image

This, however, causes an issue if the build process is not performed as root. When extracting the rootfs.tar as a non-root user, the ownership is reassigned to the extracting user which has serious security implications for the final image and will cause services to fail.

One solution, is to perform most of the build process inside of a container (where we can use root and arbitrary permissions). That's what's implemented in this PR, however, there are a few drawbacks:

1. The buildimage command/script now requires incus to use the build container. This is just a minor drawback in my opinion and should be fine.
2. In order to have full reproducibility, it would be necessary to build all binaries that are used in the container using buildroot. This means at least `bash` and `tar` should be built during the build process and pushed to the container. But maybe that's not even enough and we should build the whole container image inside skiffOS? I'm not entirely sure about the implication of using an image from the linuxcontainers image repository instead (as in my current implementation)

@paralin Please let me know what you think about those drawbacks and also if you see a better solution than using containers