### PR TITLE
Fix incus image ownership

### DIFF
--- a/configs/virt/incus/extensions/Makefile
+++ b/configs/virt/incus/extensions/Makefile
@@ -1,5 +1,5 @@
 buildimage:
-	@$(SKIFF_CURRENT_CONF_DIR)/scripts/buildimage.sh
+	@FAKEROOTDONTTRYCHOWN=1 ${BUILDROOT_DIR}/host/bin/fakeroot -- $(SKIFF_CURRENT_CONF_DIR)/scripts/buildimage.sh
 run:
 	@$(SKIFF_CURRENT_CONF_DIR)/scripts/run.sh
 exec:

--- a/configs/virt/incus/scripts/buildimage.sh
+++ b/configs/virt/incus/scripts/buildimage.sh
@@ -1,16 +1,13 @@
 #!/bin/bash
 set -eu
 
-IMAGE_NAME=skiffos/testing
-CONTAINER=skiff
-OUTPUT_PATH="$BUILDROOT_DIR/output"
 IMAGES_PATH="$BUILDROOT_DIR/images"
 INCUS_IMAGE_PATH="${IMAGES_PATH}/incus.tar.gz"
 roottar="${IMAGES_PATH}/rootfs.tar"
 
 TMPDIR="${BUILDROOT_DIR}/incus-tmp"
-trap 'rm -rf "$TMPDIR";' EXIT
 rm -rf "$TMPDIR"
+trap 'rm -rf "$TMPDIR";' EXIT
 mkdir -p "${TMPDIR}/rootfs"
 tar -xf "$roottar" -C "$TMPDIR/rootfs"
 pushd "$TMPDIR"
@@ -25,4 +22,4 @@ echo "${INCUS_METADATA:-"${default_metadata}"}" >"${TMPDIR}/metadata.yaml"
 tar caf "${INCUS_IMAGE_PATH}" rootfs metadata.yaml
 popd
 
-echo "Incus image generated successfully as ${IMAGE_NAME}"
+echo "Incus image generated successfully at ${INCUS_IMAGE_PATH}"


### PR DESCRIPTION
I finally decided to extract and recreate the tarball using fakeroot, as this is also the method used by buildroot to generate the original rootfs.tar