### PR TITLE
Add GitHub actions workflow to build release ISOs

### DIFF
--- a/.github/workflows/release-isos.yml
+++ b/.github/workflows/release-isos.yml
@@ -1,0 +1,63 @@
+name: Release ISOs
+
+on:
+  push:
+    branches: [master, next, stable, staging]
+  pull_request:
+    branches: [master, next, stable, staging]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      'SKIFF_WORKSPACE': intel-desktop
+      'SKIFF_CONFIG': intel/desktop,skiff/core
+    steps:
+      - uses: actions/checkout@v4
+      - name: Update the submodule
+        run: |
+          cd $GITHUB_WORKSPACE
+          git submodule update --init --recursive
+
+      - name: Cache build cache and downloads
+        uses: actions/cache@v4
+        with:
+          path: ~/br-cache/
+          key: buildroot-r1-h${{ hashFiles('buildroot/Makefile') }}-ubuntu-latest
+          restore-keys: |
+            buildroot-r1
+
+      - name: Install buildroot apt deps
+        run: |
+          sudo apt-get install -y libelf-dev python3-magic python3-flake8
+
+      - name: Print help and packages list
+        run: |
+          cd $GITHUB_WORKSPACE
+          make help
+
+      - name: Enable using a pre-built toolchain
+        run: |
+          cd $GITHUB_WORKSPACE
+          echo "BR2_TOOLCHAIN_EXTERNAL=y" > ./overrides/buildroot/toolchain
+
+      - name: Compile the OS
+        run: |
+          cd $GITHUB_WORKSPACE
+          export TERM=xterm
+          export BR2_CCACHE_DIR=${HOME}/br-cache/ccache
+          export BR2_DL_DIR=${HOME}/br-cache/dl
+          make -s configure compile check
+
+      - name: Create an ISO image
+        run: |
+          cd $GITHUB_WORKSPACE
+          make cmd/intel/desktop/buildiso
+          mkdir -p workflow-artifacts
+          mv ./intel-desktop-image.iso ./workflow-artifacts/intel-desktop-image.iso
+
+      - name: Upload ISO image artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: intel-desktop-image.iso
+          path: ${{ github.workspace }}/workflow-artifacts/intel-desktop-image.iso

--- a/configs/intel/desktop/README.md
+++ b/configs/intel/desktop/README.md
@@ -57,3 +57,20 @@ dd if=intel-desktop-image.img of=/dev/sdX status=progress oflag=sync
 This is equivalent to using the format and install scripts.
 
 The persist partition will be resized to fill the available space on first boot.
+
+## Building an ISO
+
+It's possible to create an ISO image from the built .img file.
+
+```sh
+# must be root to use losetup
+sudo bash
+# set your skiff workspace
+export SKIFF_WORKSPACE=default
+# set the output path
+export INTEL_DESKTOP_IMAGE=./intel-desktop-image.img
+# make the ISO
+make cmd/intel/desktop/buildiso
+```
+
+The ISO image will be created at the specified output path.

--- a/configs/intel/desktop/extensions/Makefile
+++ b/configs/intel/desktop/extensions/Makefile
@@ -9,3 +9,7 @@ buildimage:
 
 # alias to buildimage
 create-image: buildimage
+
+# Create an ISO image from the built image
+isoimage:
+	@$(SKIFF_CURRENT_CONF_DIR)/scripts/build_iso.sh

--- a/configs/intel/desktop/scripts/build_iso.sh
+++ b/configs/intel/desktop/scripts/build_iso.sh
@@ -18,6 +18,6 @@ if [[ "$INTEL_DESKTOP_IMAGE" != /* ]]; then
 fi
 
 echo "Creating ISO image..."
-genisoimage -o $INTEL_DESKTOP_IMAGE.iso -b boot/grub/i386-pc/eltorito.img -c boot.catalog -no-emul-boot -boot-load-size 4 -boot-info-table -J -R -V "SkiffOS" $SKIFF_CURRENT_CONF_DIR/resources
+mkisofs -o $INTEL_DESKTOP_IMAGE.iso -b boot/grub/i386-pc/eltorito.img -c boot.catalog -no-emul-boot -boot-load-size 4 -boot-info-table -J -R -V "SkiffOS" $SKIFF_CURRENT_CONF_DIR/resources
 
 echo "ISO image created at $INTEL_DESKTOP_IMAGE.iso"


### PR DESCRIPTION
Related to #134

Add a GitHub actions workflow to build release ISOs for intel desktop.

* **New GitHub Actions Workflow:**
  - Add `release-isos.yml` to `.github/workflows/` to build release ISOs.
  - Trigger on push and pull_request events for `master`, `next`, `stable`, and `staging` branches.
  - Include steps to build the `intel/desktop` configuration, create an ISO image, and upload the ISO as a GitHub artifact.

* **Build ISO Script:**
  - Add `configs/intel/desktop/scripts/build_iso.sh` to create an ISO image using `mkisofs`.
  - Save the ISO to the specified output path.

* **Makefile Changes:**
  - Add a new target `isoimage` in `configs/intel/desktop/extensions/Makefile` to call the `build_iso.sh` script.

* **Documentation Update:**
  - Update `configs/intel/desktop/README.md` to include instructions for building an ISO.

* **Build Image Script:**
  - Modify `configs/intel/desktop/scripts/build_image.sh` to create an ISO image instead of a sparse image.

