### PR TITLE
enable-swap: fix silent zram failure and ineffective swap priorities

### DIFF
--- a/configs-base/pre/root_overlay/opt/skiff/scripts/enable-swap.sh
+++ b/configs-base/pre/root_overlay/opt/skiff/scripts/enable-swap.sh
@@ -55,8 +55,14 @@ if [ -z "${DISABLE_ZRAM}" ] && ! (echo "${SWAP_LIST}" | grep -q "/dev/zram0"); t
     done
     swapoff /dev/zram0 2>/dev/null || true
     mkswap /dev/zram0 || true
-    # set priority to -10
-    if ! swapon -p -10 /dev/zram0 ; then
+    # Priority must be positive. swapon(8) only sets SWAP_FLAG_PREFER when the
+    # value is >= 0 (util-linux sys-utils/swapon.c: `if (priority >= 0)`), so a
+    # negative -p is dropped without an error and the kernel falls back to
+    # auto-assignment (mm/swapfile.c: `si->prio = --least_priority`, starting at
+    # -1). Priorities then follow activation order alone, and whenever zram came
+    # up after the swapfile the disk ended up ABOVE zram -- the exact opposite
+    # of what this script intends.
+    if ! swapon -p 100 /dev/zram0 ; then
         echo "Failed to enable zram0 swap, continuing..."
     else
         echo "ZRAM enabled with size ${ZRAM_SIZE}."
@@ -93,5 +99,6 @@ fi
 
 chmod 600 $SWAPFILE_PATH
 mkswap $SWAPFILE_PATH
-# set priority to -100
-swapon -p -100 $SWAPFILE_PATH
+# Positive, and below zram's 100 -- see the note above on why negative
+# priorities never reach the kernel.
+swapon -p 10 $SWAPFILE_PATH

--- a/configs-base/pre/root_overlay/opt/skiff/scripts/enable-swap.sh
+++ b/configs-base/pre/root_overlay/opt/skiff/scripts/enable-swap.sh
@@ -30,7 +30,29 @@ SWAP_LIST=$(swapon | cut -d" " -f1 | sed 1d) || true
 if [ -z "${DISABLE_ZRAM}" ] && ! (echo "${SWAP_LIST}" | grep -q "/dev/zram0"); then
     echo "Enabling ZRAM at /dev/zram0..."
     modprobe zram || true
-    zramctl -s ${ZRAM_SIZE} /dev/zram0 || true
+    # modprobe returns as soon as the module is loaded, but udev then opens the
+    # freshly created zram0 to probe it. zramctl resets the device before sizing
+    # it, and that reset fails with EBUSY while udev still holds it:
+    #
+    #   zramctl: /dev/zram0: failed to reset: Device or resource busy
+    #   mkswap: error: swap area needs to be at least 40 KiB
+    #   swapon: /dev/zram0: read swap header failed
+    #
+    # Every command in this block is `|| true` and swapon.service uses
+    # `ExecStart=-`, so the sequence failed silently and the unit still went
+    # green -- the system just came up without zram. Which boot wins the race
+    # varies: across 30 identical devices running one image, 11 had zram and 19
+    # did not.
+    command -v udevadm >/dev/null 2>&1 && udevadm settle --timeout=10 || true
+    zram_tries=0
+    while ! zramctl -s ${ZRAM_SIZE} /dev/zram0 2>/dev/null; do
+        zram_tries=$((zram_tries + 1))
+        if [ "${zram_tries}" -ge 5 ]; then
+            echo "zramctl could not size /dev/zram0 after ${zram_tries} tries."
+            break
+        fi
+        sleep 1
+    done
     swapoff /dev/zram0 2>/dev/null || true
     mkswap /dev/zram0 || true
     # set priority to -10


### PR DESCRIPTION
Two independent bugs in `configs-base/pre/root_overlay/opt/skiff/scripts/enable-swap.sh`. Both are silent: the script exits 0, `swapon.service` reports success, and the system just runs without zram — or with the disk preferred over it.

Found while investigating SD card wear on a fleet of 30 Raspberry Pi 4 running byte-identical images. 11 had zram active, 19 did not, with no configuration difference between them.

## 1. `zramctl` races udev

`modprobe zram` returns once the module is loaded, but udev then opens the newly created `zram0` to probe it. `zramctl -s` resets the device before sizing it, and that reset returns `EBUSY` while udev still holds it. From a device's boot journal:

```
enable-swap.sh: Enabling ZRAM at /dev/zram0...
zramctl: /dev/zram0: failed to reset: Device or resource busy
mkswap: error: swap area needs to be at least 40 KiB
swapon: /dev/zram0: read swap header failed
enable-swap.sh: Failed to enable zram0 swap, continuing...
```

On a device that won the race the kernel's `zram: Added device: zram0` appears *before* `zramctl` runs; on one that lost it, after. Every command in the block is `|| true` and the unit uses `ExecStart=-`, so nothing surfaces.

Fix: `udevadm settle` where available, plus a bounded retry so it does not depend on `udevadm` being present.

## 2. Negative `-p` values never reach the kernel

`swapon -p -10` and `-p -100` have no effect. swapon(8) only sets `SWAP_FLAG_PREFER` for non-negative priorities:

```c
/* util-linux sys-utils/swapon.c */
if (priority >= 0) {
        if (priority > SWAP_FLAG_PRIO_MASK)
                priority = SWAP_FLAG_PRIO_MASK;
        flags = SWAP_FLAG_PREFER | ...
```

The negative value is dropped without an error and without a non-zero exit, so the kernel auto-assigns instead:

```c
/* mm/swapfile.c */
static int least_priority = -1;
...
si->prio = --least_priority;
```

Priorities therefore came from activation order alone — first swap enabled gets -2, next -3. Whenever zram came up late, the swapfile held -2 and zram -3, putting the **disk above compressed RAM**. On SD-card systems that is the difference between compressing in RAM and writing to flash.

Fix: 100 for zram, 10 for the swapfile. Positive values fit `SWAP_FLAG_PRIO_MASK` (0x7fff) and reach the kernel, so ordering no longer depends on which ran first.

## Verification

Ran the patched script on a Raspberry Pi 4 with the zram module unloaded and no `/sys/block/zram0` present, i.e. the same cold path that races at boot:

```
Filename                        Type       Size     Used  Priority
/dev/zram0                      partition  2097148  0     100
/mnt/persist/primary.swap       file       2097148  0     10
```

Behaviour is unchanged on systems where zram was already working, apart from the priorities now being explicit rather than incidental.